### PR TITLE
Make unit selection update the unit hints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     compile("si.uom", "si-units", "0.9")
     compile("systems.uom", "systems-common", "0.8")
     compile("com.google.code.gson", "gson", "2.8.5")
+    compile(group = "org.fxmisc.easybind", name = "easybind", version = "1.0.3")
     compile(files("lib/Pathfinder-Java.jar"))
 
     fun junitJupiter(name: String, version: String = "5.2.0") =

--- a/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
@@ -1,7 +1,11 @@
 package edu.wpi.first.pathweaver;
 
+import org.fxmisc.easybind.EasyBind;
+
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
+
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
@@ -20,6 +24,7 @@ import javafx.util.StringConverter;
 import javax.measure.Unit;
 import javax.measure.quantity.Length;
 
+@SuppressWarnings("PMD.TooManyFields")
 public class CreateProjectController {
 
   @FXML
@@ -48,6 +53,14 @@ public class CreateProjectController {
   private ChoiceBox<Game> game;
   @FXML
   private ChoiceBox<Unit<Length>> length;
+  @FXML
+  private Label velocityLabel;
+  @FXML
+  private Label accelerationLabel;
+  @FXML
+  private Label jerkLabel;
+  @FXML
+  private Label wheelBaseLabel;
 
   private boolean editing = false;
 
@@ -85,6 +98,31 @@ public class CreateProjectController {
 
     length.getItems().addAll(PathUnits.LENGTHS);
     length.getSelectionModel().selectFirst();
+    length.setConverter(new StringConverter<>() {
+      @Override
+      public String toString(Unit<Length> object) {
+        return object.getName();
+      }
+
+      @Override
+      public Unit<Length> fromString(String string) {
+        throw new UnsupportedOperationException();
+      }
+    });
+
+    var lengthUnit = EasyBind.monadic(length.getSelectionModel().selectedItemProperty());
+    velocityLabel.textProperty().bind(lengthUnit.map(unit -> {
+      return "Maximum velocity (" + PathUnits.velocity(unit) + ")";
+    }));
+    accelerationLabel.textProperty().bind(lengthUnit.map(unit -> {
+      return "Maximum acceleration (" + PathUnits.acceleration(unit) + ")";
+    }));
+    jerkLabel.textProperty().bind(lengthUnit.map(unit -> {
+      return "Maximum jerk (" + PathUnits.jerk(unit) + ")";
+    }));
+    wheelBaseLabel.textProperty().bind(lengthUnit.map(unit -> {
+      return "Distance between the left and right of the wheel base (" + unit.getName().toLowerCase(Locale.US) + ")";
+    }));
 
     // We are editing a project
     if (ProjectPreferences.getInstance() != null) {

--- a/src/main/java/edu/wpi/first/pathweaver/PathUnits.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathUnits.java
@@ -48,9 +48,9 @@ public final class PathUnits extends AbstractSystemOfUnits {
     return addUnit(unit, name, label, true);
   }
 
-  private static <U extends Unit<?>> U addUnit(U unit, String name, String text, boolean isLabel) {
+  private static <U extends Unit<?>> U addUnit(U unit, String name, String label, boolean isLabel) {
     if (isLabel) {
-      SimpleUnitFormat.getInstance().label(unit, text);
+      SimpleUnitFormat.getInstance().label(unit, label);
     }
     if (name != null && unit instanceof AbstractUnit) {
       return Helper.addUnit(INSTANCE.units, unit, name);
@@ -108,6 +108,27 @@ public final class PathUnits extends AbstractSystemOfUnits {
       default:
         throw new IllegalArgumentException("Unsupported length unit: " + unit);
     }
+  }
+
+  /**
+   * Generates a velocity string for {unit} per second such as m/s, ft/s, etc.
+   */
+  public static String velocity(Unit<Length> unit) {
+    return SimpleUnitFormat.getInstance().format(unit) + "/s";
+  }
+
+  /**
+   * Generates an acceleration string for {unit} per second per second such as m/s², ft/s², etc.
+   */
+  public static String acceleration(Unit<Length> unit) {
+    return SimpleUnitFormat.getInstance().format(unit) + "/s²";
+  }
+
+  /**
+   * Generates a jerk string for {unit} per second per second per second such as m/s³, ft/s³, etc.
+   */
+  public static String jerk(Unit<Length> unit) {
+    return SimpleUnitFormat.getInstance().format(unit) + "/s³";
   }
 
 }

--- a/src/main/resources/edu/wpi/first/pathweaver/createProject.fxml
+++ b/src/main/resources/edu/wpi/first/pathweaver/createProject.fxml
@@ -55,10 +55,10 @@
             <TextField fx:id="maxJerk" GridPane.columnIndex="1" GridPane.rowIndex="6" />
             <TextField fx:id="wheelBase" GridPane.columnIndex="1" GridPane.rowIndex="7" />
             <Label text="Time delta between points (seconds)" GridPane.columnIndex="2" GridPane.rowIndex="3" />
-            <Label text="Maximum velocity (length per second)" GridPane.columnIndex="2" GridPane.rowIndex="4" />
-            <Label text="Maximum acceleration (velocity per second)" GridPane.columnIndex="2" GridPane.rowIndex="5" />
-            <Label text="Maximum jerk (acceleration per second)" GridPane.columnIndex="2" GridPane.rowIndex="6" />
-            <Label text="Distance between left and right of wheel base" GridPane.columnIndex="2" GridPane.rowIndex="7" />
+            <Label fx:id="velocityLabel" GridPane.columnIndex="2" GridPane.rowIndex="4" />
+            <Label fx:id="accelerationLabel" GridPane.columnIndex="2" GridPane.rowIndex="5" />
+            <Label fx:id="jerkLabel" GridPane.columnIndex="2" GridPane.rowIndex="6" />
+            <Label fx:id="wheelBaseLabel" GridPane.columnIndex="2" GridPane.rowIndex="7" />
             <ButtonBar prefHeight="40.0" prefWidth="200.0" GridPane.columnIndex="2" GridPane.rowIndex="8">
               <buttons>
                 <Button fx:id="cancel" mnemonicParsing="false" onAction="#cancel" text="Cancel" />


### PR DESCRIPTION
Display units in selection box as their name instead of their abbreviation (eg m -> meter)
Add dependency on EasyBind

# Screenshots

**Length Unit: Meter**
![image](https://user-images.githubusercontent.com/6320992/49118493-705aea00-f272-11e8-8144-4dec58eeaf58.png)

**Length Unit: Foot**
![image](https://user-images.githubusercontent.com/6320992/49118502-76e96180-f272-11e8-975d-2e5d0e480b30.png)
